### PR TITLE
Fix: Going to payments screen and then leaving crashes app

### DIFF
--- a/src/components/customer/CardSection.js
+++ b/src/components/customer/CardSection.js
@@ -111,7 +111,7 @@ class CardSection extends Component {
   }
 
   componentWillUnmount() {
-    this.removeListener();
+    this.removeListener && this.removeListener();
   }
 
   renderCardForm = () => {


### PR DESCRIPTION
fix: added a check for a listener before removing it since we do not add the listener until someone trys to add a card