### PR TITLE
change auth domain to show paynless.co

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -4,7 +4,7 @@ require("firebase/firestore");
 
 const config = {
   apiKey: "AIzaSyC7IgI5-j77wekNYOxFd0_-FNGq3FuoOH4",
-  authDomain: "paynless-db.firebaseapp.com",
+  authDomain: "paynless.co",
   databaseURL: "https://paynless-db.firebaseio.com",
   projectId: "paynless-db",
   storageBucket: "paynless-db.appspot.com",


### PR DESCRIPTION
Summary: Remove paynless.db reference in google redirect page